### PR TITLE
Add Polar checkout integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 NEXT_PUBLIC_APP_URL=https://www.acme.ai
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_aW50aW1hdGUtYnVsbGZyb2ctMzkuY2xlcmsuYWNjb3VudHMuZGV2JA
 CLERK_SECRET_KEY=sk_test_VCZYG7RBF72AXXFz8Al6SsKQIrC1CK0x1m0rqWYNZv
+POLAR_API_KEY=your-polar-api-key
+POLAR_PRODUCT_ID=your-polar-product-id

--- a/src/app/api/polar/checkout/route.ts
+++ b/src/app/api/polar/checkout/route.ts
@@ -1,0 +1,31 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const res = await fetch("https://api.polar.sh/api/v1/checkout", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.POLAR_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      productId: process.env.POLAR_PRODUCT_ID,
+      successUrl: `${process.env.NEXT_PUBLIC_APP_URL}/downloads/success`,
+      cancelUrl: `${process.env.NEXT_PUBLIC_APP_URL}/downloads/cancel`,
+      userId,
+    }),
+  });
+
+  if (!res.ok) {
+    console.error("Polar API error", await res.text());
+    return NextResponse.json({ error: "Failed to create session" }, { status: 500 });
+  }
+
+  const data = await res.json();
+  return NextResponse.json({ url: data.url });
+}

--- a/src/app/api/polar/webhook/route.ts
+++ b/src/app/api/polar/webhook/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { queryItems, updateItem } from "@/lib/dynamodb";
+
+export async function POST(req: NextRequest) {
+  const rawBody = await req.text();
+  const signature = req.headers.get("polar-signature") || "";
+  const expected = crypto
+    .createHmac("sha256", process.env.POLAR_WEBHOOK_SECRET || "")
+    .update(rawBody)
+    .digest("hex");
+
+  if (signature !== expected) {
+    return new NextResponse("Invalid signature", { status: 401 });
+  }
+
+  const event = JSON.parse(rawBody);
+
+  if (event.type === "payment.succeeded") {
+    const userId = event.data?.userId || event.userId || event.metadata?.userId;
+    if (userId) {
+      const { Items } = await queryItems(
+        "S3Console",
+        "clerkId = :id",
+        { ":id": userId }
+      );
+      const email = Items?.[0]?.email;
+      if (email) {
+        await updateItem(
+          "S3Console",
+          { email },
+          "SET paid = :p",
+          { ":p": true }
+        );
+      }
+    }
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/src/app/downloads/cancel/page.tsx
+++ b/src/app/downloads/cancel/page.tsx
@@ -1,0 +1,9 @@
+import Section from "@/components/section";
+
+export default function CancelPage() {
+  return (
+    <Section title="Payment Canceled" className="py-20 text-center">
+      <p className="text-lg">Payment was canceled. You can try again anytime.</p>
+    </Section>
+  );
+}

--- a/src/app/downloads/page.tsx
+++ b/src/app/downloads/page.tsx
@@ -1,5 +1,5 @@
 import Section from "@/components/section";
-import { Button } from "@/components/ui/button";
+import CheckoutButton from "@/components/checkout-button";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { FaWindows, FaApple } from "react-icons/fa";
@@ -66,7 +66,7 @@ export default async function DownloadsPage() {
       )}
 
       <div className="mt-12 flex justify-center">
-        <Button size="lg">Buy LifeTime Access now</Button>
+        <CheckoutButton />
       </div>
     </Section>
   );

--- a/src/app/downloads/success/page.tsx
+++ b/src/app/downloads/success/page.tsx
@@ -1,0 +1,9 @@
+import Section from "@/components/section";
+
+export default function SuccessPage() {
+  return (
+    <Section title="Payment Success" className="py-20 text-center">
+      <p className="text-lg">Thank you for your purchase. You can now download the app.</p>
+    </Section>
+  );
+}

--- a/src/components/checkout-button.tsx
+++ b/src/components/checkout-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { Button } from "@/components/ui/button";
+
+export default function CheckoutButton() {
+  const handleClick = async () => {
+    const res = await fetch("/api/polar/checkout", { method: "POST" });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.url) {
+        window.location.href = data.url;
+      }
+    }
+  };
+
+  return (
+    <Button size="lg" onClick={handleClick}>
+      Buy LifeTime Access now
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- define Polar API credentials in `.env.example`
- implement checkout & webhook API routes
- add client-side checkout button
- show payment success or cancel pages
- redirect from downloads page to Polar checkout

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e9ba6a4848325be1d22cdb429bbb3