### PR TITLE
Add optional index for DynamoDB queries

### DIFF
--- a/src/app/api/polar/webhook/route.ts
+++ b/src/app/api/polar/webhook/route.ts
@@ -22,7 +22,8 @@ export async function POST(req: NextRequest) {
       const { Items } = await queryItems(
         "S3Console",
         "clerkId = :id",
-        { ":id": userId }
+        { ":id": userId },
+        "clerkId-index"
       );
       const email = Items?.[0]?.email;
       if (email) {

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -61,12 +61,14 @@ export async function deleteItem(tableName: string, key: Record<string, any>) {
 export async function queryItems(
   tableName: string,
   keyConditionExpression: string,
-  expressionAttributeValues: Record<string, any>
+  expressionAttributeValues: Record<string, any>,
+  indexName?: string
 ) {
   const command = new QueryCommand({
     TableName: tableName,
     KeyConditionExpression: keyConditionExpression,
     ExpressionAttributeValues: expressionAttributeValues,
+    ...(indexName ? { IndexName: indexName } : {}),
   });
   return docClient.send(command);
 }


### PR DESCRIPTION
## Summary
- allow `queryItems` to accept an optional `indexName`
- apply index when querying in the Polar webhook handler

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ea1ed42708325ad320eab06bb4ba3