### PR TITLE
Add disabled Linux download card

### DIFF
--- a/src/app/downloads/page.tsx
+++ b/src/app/downloads/page.tsx
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import {
   FaWindows,
   FaApple,
+  FaLinux,
   FaDownload,
   FaCrown,
   FaKey,
@@ -275,7 +276,7 @@ export default function DownloadsPage() {
           </div>
 
           {/* Download Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8 mb-16">
             {/* Windows Card */}
             <div className="group relative overflow-hidden border border-slate-200 dark:border-slate-700 rounded-2xl p-8 text-center transition-all duration-300 hover:shadow-2xl hover:shadow-primary/20 bg-white dark:bg-slate-800 hover:border-primary/30">
               <div className="absolute inset-0 bg-gradient-to-br from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
@@ -319,6 +320,32 @@ export default function DownloadsPage() {
                   <FaDownload className="mr-2 h-4 w-4" />
                   Download for macOS
                 </Button>
+              </div>
+            </div>
+
+            {/* Linux Card */}
+            <div className="group relative overflow-hidden border border-slate-200 dark:border-slate-700 rounded-2xl p-8 text-center transition-all duration-300 hover:shadow-2xl hover:shadow-primary/20 bg-white dark:bg-slate-800 hover:border-primary/30">
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+              <div className="relative z-10">
+                <div className="inline-flex items-center justify-center w-20 h-20 bg-primary/10 rounded-2xl mb-6 group-hover:scale-110 transition-transform duration-300">
+                  <FaLinux className="h-10 w-10 text-primary" />
+                </div>
+                <h3 className="text-2xl font-bold text-slate-900 dark:text-white mb-3">
+                  Linux
+                </h3>
+                <p className="text-slate-600 dark:text-slate-400 mb-6">
+                  Ubuntu &amp; other major distributions
+                </p>
+                <Button
+                  disabled
+                  className="w-full bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-300 cursor-not-allowed opacity-60"
+                >
+                  <FaDownload className="mr-2 h-4 w-4" />
+                  Download for Linux
+                </Button>
+                <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+                  Coming soon
+                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add the Linux icon to the downloads page and expand the download grid layout
- include a Linux download card with a disabled button and helper text

## Testing
- pnpm lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cefd9ddff8832583bea510991e7fa4