### PR TITLE
Enable Linux download button

### DIFF
--- a/src/app/downloads/page.tsx
+++ b/src/app/downloads/page.tsx
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import {
   FaWindows,
   FaApple,
+  FaLinux,
   FaDownload,
   FaCrown,
   FaKey,
@@ -211,6 +212,52 @@ export default function DownloadsPage() {
     }, 8000);
   };
 
+  const handleLinuxDownload = () => {
+    const downloadLink =
+      "https://s3consolelinux.s3.ap-south-1.amazonaws.com/s3Console_1.0.74_amd64.deb";
+
+    const link = document.createElement("a");
+    link.href = downloadLink;
+    link.download = "s3Console_1.0.74_amd64.deb";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    if (typeof window !== "undefined" && window.twq) {
+      window.twq("event", "tw-pyshe-pyshf", {
+        email_address: userData?.email || null,
+        conversion_type: "linux_download",
+      });
+    }
+
+    const notification = document.createElement("div");
+    notification.className =
+      "fixed bottom-8 right-8 bg-slate-900 text-white p-6 rounded-lg shadow-xl z-50 max-w-md animate-in slide-in-from-bottom";
+    notification.innerHTML = `
+      <div class="flex items-start gap-4">
+        <div class="flex-shrink-0">
+          <svg class="h-6 w-6 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+        </div>
+        <div class="flex-1">
+          <p class="font-semibold mb-1">Download Started!</p>
+          <p class="text-sm text-slate-300 mb-2">Your S3Console download should begin shortly.</p>
+          <p class="text-xs text-slate-400">If the download doesn't start automatically, <a href="${downloadLink}" class="text-primary hover:underline">click here</a>.</p>
+        </div>
+      </div>
+    `;
+
+    document.body.appendChild(notification);
+
+    setTimeout(() => {
+      notification.classList.add("animate-out", "slide-out-to-bottom");
+      setTimeout(() => {
+        document.body.removeChild(notification);
+      }, 300);
+    }, 8000);
+  };
+
   return (
     <>
       <Header />
@@ -275,7 +322,7 @@ export default function DownloadsPage() {
           </div>
 
           {/* Download Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8 mb-16">
             {/* Windows Card */}
             <div className="group relative overflow-hidden border border-slate-200 dark:border-slate-700 rounded-2xl p-8 text-center transition-all duration-300 hover:shadow-2xl hover:shadow-primary/20 bg-white dark:bg-slate-800 hover:border-primary/30">
               <div className="absolute inset-0 bg-gradient-to-br from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
@@ -319,6 +366,32 @@ export default function DownloadsPage() {
                   <FaDownload className="mr-2 h-4 w-4" />
                   Download for macOS
                 </Button>
+              </div>
+            </div>
+
+            {/* Linux Card */}
+            <div className="group relative overflow-hidden border border-slate-200 dark:border-slate-700 rounded-2xl p-8 text-center transition-all duration-300 hover:shadow-2xl hover:shadow-primary/20 bg-white dark:bg-slate-800 hover:border-primary/30">
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+              <div className="relative z-10">
+                <div className="inline-flex items-center justify-center w-20 h-20 bg-primary/10 rounded-2xl mb-6 group-hover:scale-110 transition-transform duration-300">
+                  <FaLinux className="h-10 w-10 text-primary" />
+                </div>
+                <h3 className="text-2xl font-bold text-slate-900 dark:text-white mb-3">
+                  Linux
+                </h3>
+                <p className="text-slate-600 dark:text-slate-400 mb-6">
+                  Ubuntu &amp; other major distributions
+                </p>
+                <Button
+                  onClick={handleLinuxDownload}
+                  className="w-full bg-primary hover:bg-primary/90 text-white group-hover:shadow-lg transition-all duration-300"
+                >
+                  <FaDownload className="mr-2 h-4 w-4" />
+                  Download for Linux
+                </Button>
+                <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+                  Debian-based distributions (.deb)
+                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add a Linux download handler that starts the .deb package download and tracks analytics
- enable the Linux download card button with consistent styling and updated helper text

## Testing
- pnpm lint *(fails: existing lint errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68cefd9ddff8832583bea510991e7fa4